### PR TITLE
feat: add age verification modal (21+ gate)

### DIFF
--- a/src/components/AgeVerificationModal.tsx
+++ b/src/components/AgeVerificationModal.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+const STORAGE_KEY = 'age-verified';
+const REDIRECT_URL = 'https://www.misterrogers.org';
+
+export default function AgeVerificationModal() {
+  const [isVisible, setIsVisible] = useState(false);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    try {
+      if (sessionStorage.getItem(STORAGE_KEY) !== 'true') {
+        setIsVisible(true);
+      }
+    } catch {
+      // sessionStorage unavailable — show the modal to be safe
+      setIsVisible(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isVisible) {
+      document.body.style.overflow = 'hidden';
+      confirmRef.current?.focus();
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isVisible]);
+
+  function handleConfirm() {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      // Proceed even if sessionStorage is unavailable
+    }
+    setIsVisible(false);
+  }
+
+  function handleDeny() {
+    window.location.assign(REDIRECT_URL);
+  }
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="age-modal-heading"
+    >
+      <div class="w-full max-w-md rounded-2xl bg-light-card p-8 shadow-2xl dark:bg-dark-card">
+        <div class="mb-6 text-center">
+          <p class="text-5xl" aria-hidden="true">🌿</p>
+          <h1
+            id="age-modal-heading"
+            class="mt-4 text-2xl font-bold text-light-text-heading dark:text-white"
+          >
+            Are you 21 or older?
+          </h1>
+          <p class="mt-2 text-sm text-light-text-body dark:text-dark-text-body">
+            You must be 21 years of age or older to enter this site. Please verify your age to
+            continue.
+          </p>
+        </div>
+
+        <div class="flex flex-col gap-3 sm:flex-row">
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={handleConfirm}
+            class="flex-1 cursor-pointer rounded-xl bg-[#6bba62] px-6 py-3 text-center font-semibold text-white transition-opacity hover:opacity-80"
+          >
+            Yes, I'm 21+
+          </button>
+          <button
+            type="button"
+            onClick={handleDeny}
+            class="flex-1 cursor-pointer rounded-xl border border-light-input-border px-6 py-3 font-semibold text-light-text-body transition-colors hover:bg-light-input-bg dark:border-dark-border dark:text-dark-text-body dark:hover:bg-dark-background"
+          >
+            No, I'm Under 21
+          </button>
+        </div>
+
+        <p class="mt-6 text-center text-xs text-light-text-body dark:text-dark-text-body">
+          By entering this site you agree to our{' '}
+          <a href="/links" class="underline hover:opacity-80">
+            terms of use
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ import Dots from '../components/Dots.astro';
 import Hosts from '../components/Hosts.astro';
 import InfoCard from '../components/InfoCard.astro';
 import Platforms from '../components/Platforms.astro';
+import AgeVerificationModal from '../components/AgeVerificationModal';
 import Player from '../components/Player';
 import ShowArtwork from '../components/ShowArtwork.astro';
 
@@ -181,6 +182,7 @@ const description = Astro.props.description ?? starpodConfig.description;
       <Hosts />
       <InfoCard />
     </footer>
+    <AgeVerificationModal client:only="preact" transition:persist="age-verification" />
     <div id="audio-player">
       <Player client:only="preact" transition:persist="player" />
     </div>

--- a/tests/ageverification.spec.ts
+++ b/tests/ageverification.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+const MODAL_HEADING = 'Are you 21 or older?';
+const CONFIRM_BUTTON = "Yes, I'm 21+";
+const DENY_BUTTON = "No, I'm Under 21";
+const REDIRECT_URL = 'https://www.misterrogers.org';
+
+test.describe('Age Verification Modal', () => {
+  test('modal is visible on first visit (no localStorage)', async ({ page }) => {
+    await page.goto('/');
+
+    const heading = page.getByRole('heading', { name: MODAL_HEADING });
+    await expect(heading).toBeVisible();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  test('clicking "Yes, I\'m 21+" dismisses the modal and sets localStorage', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('button', { name: CONFIRM_BUTTON }).click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    const storageValue = await page.evaluate(() => sessionStorage.getItem('age-verified'));
+    expect(storageValue).toBe('true');
+  });
+
+  test('modal does NOT appear when age-verified is already set in localStorage', async ({
+    page
+  }) => {
+    await page.addInitScript(() => {
+      sessionStorage.setItem('age-verified', 'true');
+    });
+
+    await page.goto('/');
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+  });
+
+  test('clicking "No, I\'m Under 21" redirects to misterrogers.org', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const navigationPromise = page.waitForURL(new RegExp(REDIRECT_URL.replace('https://', '')), {
+      timeout: 15000,
+      waitUntil: 'domcontentloaded'
+    });
+
+    await page.getByRole('button', { name: DENY_BUTTON }).click();
+
+    await navigationPromise;
+
+    expect(page.url()).toContain('misterrogers.org');
+  });
+
+  test('modal is not shown again after confirming age and reloading', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: CONFIRM_BUTTON }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    await page.reload();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+  });
+});

--- a/tests/ageverification.spec.ts
+++ b/tests/ageverification.spec.ts
@@ -47,7 +47,8 @@ test.describe('Age Verification Modal', () => {
 
     await expect(page.getByRole('dialog')).toBeVisible();
 
-    const navigationPromise = page.waitForURL(new RegExp(REDIRECT_URL.replace('https://', '')), {
+    const redirectHostPattern = REDIRECT_URL.replace('https://', '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const navigationPromise = page.waitForURL(new RegExp(redirectHostPattern), {
       timeout: 15000,
       waitUntil: 'domcontentloaded'
     });


### PR DESCRIPTION
feat(age-gate): add session-scoped age verification modal

- Implement AgeVerificationModal as a Preact component with sessionStorage persistence
- Mount in Layout.astro with client:only="preact" and transition:persist
- Confirm (21+) dismisses modal; deny redirects to misterrogers.org
- Body scroll locked while modal is visible; ARIA dialog attributes for accessibility
- Add Playwright spec with 5 tests covering all user paths across Chromium, Firefox, and WebKit